### PR TITLE
Fix parser edge cases in C++ score renderer

### DIFF
--- a/src/simple.cpp
+++ b/src/simple.cpp
@@ -50,9 +50,6 @@ score_t parse(std::string str_in) {
 
     for (; iter != end; ++iter) {
         std::string token = *iter;
-        if (token.empty()) {
-            continue;
-        }
         // instrument headers
         if (token.back() == ':') {
             if (token == "sine:") {

--- a/src/simple.cpp
+++ b/src/simple.cpp
@@ -50,6 +50,9 @@ score_t parse(std::string str_in) {
 
     for (; iter != end; ++iter) {
         std::string token = *iter;
+        if (token.empty()) {
+            continue;
+        }
         // instrument headers
         if (token.back() == ':') {
             if (token == "sine:") {
@@ -148,6 +151,10 @@ int playscore(int argc, char **argv) {
     // TODO: add persistent length settings
     std::ifstream f_score;
     f_score.open(score_filename);
+    if (!f_score.is_open()) {
+        std::cerr << "unable to open score file: " << score_filename << std::endl;
+        return 1;
+    }
     std::stringstream sstr_in;
     sstr_in << f_score.rdbuf();
     f_score.close();


### PR DESCRIPTION
### Motivation
- Prevent crashes and confusing behavior when parsing malformed or whitespace-heavy score text and when the requested score file cannot be opened by failing fast with a clear error.

### Description
- Skip empty tokens in `parse(std::string)` to avoid calling `token.back()` on empty strings and add a file-open guard in `playscore` that prints `unable to open score file: <filename>` and returns `1` if `std::ifstream` fails to open the score.

### Testing
- Ran `make` which compiled the project successfully (build completed without errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2492f96788328af977cd1bf44959a)